### PR TITLE
layerid in vector tiles should match _info

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function CardboardTiles(uri, callback) {
         json: {
             vector_layers: [
                 {
-                    id: uri.dataset.replace(/\./g, '_'),
+                    id: layerid(uri.dataset),
                     minzoom: defaultMinZoom,
                     maxzoom: defaultMaxZoom
                 }
@@ -140,7 +140,7 @@ CardboardTiles.prototype._getXml = function(bbox, callback) {
         var params = _({
             buffer: defaultBuffer,
             geojson: geojson,
-            dataset: dataset,
+            dataset: layerid(dataset),
             minzoom: defaultMinZoom,
             maxzoom: defaultMaxZoom
         }).extend(info);
@@ -149,4 +149,8 @@ CardboardTiles.prototype._getXml = function(bbox, callback) {
 
         callback(null, preparedXml);
     });
+}
+
+function layerid(id) {
+    return id.replace(/[^a-zA-Z0-9_]/ig, '_');
 }

--- a/test/index.js
+++ b/test/index.js
@@ -12,7 +12,7 @@ var path = require('path');
 var config = {
     table: 'geo',
     endpoint: 'http://localhost:4567',
-    dataset: 'test'
+    dataset: 'test.dataset'
 };
 
 var dynalite;
@@ -88,7 +88,7 @@ var expectedInfo = {
     json: {
         vector_layers: [
             {
-                id: 'test',
+                id: 'test_dataset',
                 minzoom:0,
                 maxzoom:14
             }
@@ -119,8 +119,10 @@ function testTile(data, t) {
         t.ifError(err, 'unzipped tile');
         
         var tile = new VectorTile(new Protobuf(tileData));
-        var layer = tile.layers[config.dataset];
+        var sanitized = config.dataset.replace(/[^a-zA-Z0-9_]/ig, '_');
+        var layer = tile.layers[sanitized];
         t.ok(layer, 'contains layer');
+        t.equal(layer.name, sanitized, 'contains sanitized layer name');
         t.equal(layer.length, 43, 'contains correct number of features');
 
         var geom = layer.feature(0).loadGeometry();


### PR DESCRIPTION
Replace special characters with `_` in layer ids in both mapnik XML and `_info`.
