### PR TITLE
Don't require that AWS creds be set by env.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,16 +31,10 @@ function CardboardTiles(uri, callback) {
         return callback(new Error('Missing keys in config: ' + missingKeys.join(', ')));
 
     this._connection = {
-        awsKey: process.env.AWS_ACCESS_KEY_ID,
-        awsSecret: process.env.AWS_SECRET_ACCESS_KEY,
-        sessionToken: process.env.AWS_SESSION_TOKEN,
         table: uri.table,
         endpoint:  uri.endpoint,
         region: process.env.AWS_DEFAULT_REGION || 'us-east-1'
     };
-
-    if (!this._connection.awsKey || !this._connection.awsSecret || !this._connection.region)
-        return callback(new Error('Missing AWS credentials in environment'));
 
     this._dataset = uri.dataset;
 

--- a/test/index.js
+++ b/test/index.js
@@ -18,13 +18,9 @@ var config = {
 var dynalite;
 
 // Expects AWS creds to be set via env vars
-function setCreds() {
-    process.env.AWS_ACCESS_KEY_ID = 'fake';
-    process.env.AWS_SECRET_ACCESS_KEY = 'fake';
-    process.env.AWS_DEFAULT_REGION = 'fake';    
-}
-
-setCreds();
+process.env.AWS_ACCESS_KEY_ID = 'fake';
+process.env.AWS_SECRET_ACCESS_KEY = 'fake';
+process.env.AWS_DEFAULT_REGION = 'fake';
 
 test('setup', function(t) {
     var fixture = path.join(__dirname, 'fixtures', 'random-data.geojson');
@@ -52,15 +48,6 @@ test('initialization: sanitizes dataset name', function(t) {
     new CardboardTiles(newDatasetName, function(err, source) {
         t.ifError(err, 'initialized successfully');
         t.equal(source._info.json.vector_layers[0].id, 'test_sanitization', 'sanitized properly');
-        t.end();
-    });
-});
-
-test('initialization: fails without AWS creds in environment', function(t) {
-    delete process.env.AWS_SECRET_ACCESS_KEY;
-    new CardboardTiles(config, function(err, source) {
-        t.equal(err.message, 'Missing AWS credentials in environment', 'expected error');
-        setCreds();
         t.end();
     });
 });


### PR DESCRIPTION
Unblocked by https://github.com/mapbox/tilelive-s3/pull/24. tilelive-cardboard should use aws-sdk's build-in methods for getting credentials, whether that is via ENV, config file, or EC2 metadata API.
